### PR TITLE
Remove references to old website on main page

### DIFF
--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -11,9 +11,9 @@ header:
     subTitle: See the release notes
     title: v1.1 Release available now
   buttons:
-    - link: "https://facebookincubator.github.io/magma/docs/basics/quick_start_guide"
+    - link: "https://magma.github.io/magma/docs/basics/quick_start_guide"
       text: Quick Start Guide
-    - link: "https://facebookincubator.github.io/magma/docs/basics/prerequisites"
+    - link: "https://github.com/magma/magma"
       text: Download
   display: true
   subTitle:


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

This change set fixes the following links on the main page:
- Quick Start Guide points to old website
- Download points to Pre-requisites page instead of Git repo